### PR TITLE
Indexar columnas por demanda

### DIFF
--- a/db/src/main/java/org/db/core/Attribute.java
+++ b/db/src/main/java/org/db/core/Attribute.java
@@ -7,6 +7,12 @@ public class Attribute {
 	String columnName;
 	String type;
 
+	public Attribute(int index, Object scan, String columnName) {
+		super();
+		this.index = index;
+		this.scan = scan;
+		this.columnName = columnName;
+	}
 	public Attribute(int index, Object scan, String columnName, String type) {
 		super();
 		this.index = index;

--- a/db/src/main/java/org/db/core/Attribute.java
+++ b/db/src/main/java/org/db/core/Attribute.java
@@ -5,12 +5,14 @@ public class Attribute {
 	int index;
 	Object scan;
 	String columnName;
+	String type;
 
-	public Attribute(int index, Object scan, String columnName) {
+	public Attribute(int index, Object scan, String columnName, String type) {
 		super();
 		this.index = index;
 		this.scan = scan;
 		this.columnName = columnName;
+		this.type = type;
 	}
 	public int getIndex() {
 		return index;
@@ -30,5 +32,10 @@ public class Attribute {
 	public void setColumnName(String columnName) {
 		this.columnName = columnName;
 	}
-
+	public String getType() {
+		return type;
+	}
+	public void setType(String type) {
+		this.type = type;
+	}
 }

--- a/db/src/main/java/org/db/scan/IndexScan.java
+++ b/db/src/main/java/org/db/scan/IndexScan.java
@@ -24,11 +24,15 @@ public class IndexScan implements Iterator<List<Object>>{
 		this.indexer = indexer;
 		if (indexer.columnIsHashIndexed(tableName, columnName)) {
 			indexMethod = "hash";
-			blockLines = Indexer.hashIndexes.get(tableName).get(columnName).values().iterator();
 		} else if (indexer.columnIsBTreeIndexed(tableName, columnName)) {
 			indexMethod = "btree";
 		} else {
-			// TODO: indexColumn
+			indexMethod = indexer.indexColumn(tableName, columnName);
+		}
+		if (indexMethod.equals("hash")) {
+			blockLines = Indexer.hashIndexes.get(tableName).get(columnName).values().iterator();
+		} else {
+			// btree iterator
 		}
 		loadSchema();
 	}

--- a/db/src/test/java/org/db/IndexScanTest.java
+++ b/db/src/test/java/org/db/IndexScanTest.java
@@ -8,6 +8,7 @@ import org.db.scan.IndexScan;
 public class IndexScanTest {
     public static void main(String[] args){
         // Hash table test
+        System.out.println("------- Hash indexing test (table: A)-------");
         Indexer indexer = new Indexer();
         indexer.indexTable("A");
         IndexScan aIndexScan = new IndexScan("A", "b", indexer);
@@ -15,6 +16,14 @@ public class IndexScanTest {
             System.out.println(aIndexScan.next());
         };
         // Btree test
+        System.out.println("\n------- BTree indexing test (table: B) -------");
         indexer.indexTable("B");
+
+        System.out.println("\n------- Indexing when column is not indexed test (table: B, column:x) -------");
+        // Test when column is not indexed
+        IndexScan bIndexScan = new IndexScan("B", "x", indexer);
+        while (bIndexScan.hasNext()) {
+            System.out.println(bIndexScan.next());
+        };
     }
 }


### PR DESCRIPTION
En caso de que la columna solicitada no este indexada, el IndexScan usa el método ofrecidos por Indexer para indexar la tabla de acuerdo a la columna requerida.

El Indexer verficará que efectivamente la columna no se encuentre indexada. Además, el método de indexado será seleccionado de acuerdo al criterio expuesto en el enunciado de este proyecto:

> la columna especificada no está indexada, entonces los datos numéricos se deben indexar usando árboles y los datos de texto con tablas Hash.
